### PR TITLE
Add tag to resource_type since 'latest' tag not present on docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ resource_types:
   type: docker-image
   source:
     repository: snapkitchen/concourse-packer-resource
+    tag: 1.4.3
 
 resources:
 - name: build-ami


### PR DESCRIPTION
Without the optional `tag` in the docker-image resource type, it defaults
to 'latest' which is not present on https://hub.docker.com/r/snapkitchen/concourse-packer-resource/tags

Therefore, therefore a job attempting to use this fails with:
`no versions of image available`